### PR TITLE
chore(*) update for newer versions of kong

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,14 @@
+std             = "ngx_lua"
+unused_args     = false
+redefined       = false
+max_line_length = false
+
+
+globals = {
+    "kong",
+}
+
+
+files["specs/**/*.lua"] = {
+    std = "ngx_lua+busted",
+}

--- a/kong/plugins/openwhisk/handler.lua
+++ b/kong/plugins/openwhisk/handler.lua
@@ -1,5 +1,4 @@
 local BasePlugin    = require "kong.plugins.base_plugin"
-local singletons    = require "kong.singletons"
 local responses     = require "kong.tools.responses"
 local constants     = require "kong.constants"
 local get_post_args = require "kong.tools.public".get_body_args
@@ -10,6 +9,7 @@ local cjson         = require "cjson.safe"
 local multipart     = require "multipart"
 
 
+local kong          = kong
 local tostring      = tostring
 local concat        = table.concat
 local pairs         = pairs
@@ -73,7 +73,7 @@ local function send(status, content, headers)
     ngx.header["Content-Length"] = #content
   end
 
-  if singletons.configuration.enabled_headers[constants.HEADERS.VIA] then
+  if kong.configuration.enabled_headers[constants.HEADERS.VIA] then
     ngx.header[constants.HEADERS.VIA] = server_header
   end
 

--- a/kong/plugins/openwhisk/schema.lua
+++ b/kong/plugins/openwhisk/schema.lua
@@ -1,14 +1,20 @@
 return {
+  name = "openwhisk",
   fields = {
-    timeout       = { type = "number",  default  = 60000 },
-    keepalive     = { type = "number",  default  = 60000 },
-    service_token = { type = "string"                    },
-    host          = { type = "string",  required = true  },
-    port          = { type = "number",  default  = 443   },
-    path          = { type = "string",  required = true  },
-    action        = { type = "string",  required = true  },
-    https         = { type = "boolean", default  = true  },
-    https_verify  = { type = "boolean", default  = false },
-    result        = { type = "boolean", default  = true  },
+    config = {
+      type = "record",
+      fields = {
+        { timeout       = { type = "integer", default  = 60000 } },
+        { keepalive     = { type = "integer", default  = 60000 } },
+        { service_token = { type = "string"                     } },
+        { host          = { type = "string",  required = true   } },
+        { port          = { type = "integer", default  = 443   } },
+        { path          = { type = "string",  required = true   } },
+        { action        = { type = "string",  required = true   } },
+        { https         = { type = "boolean", default  = true   } },
+        { https_verify  = { type = "boolean", default  = false  } },
+        { result        = { type = "boolean", default  = true   } },
+      }
+    }
   }
 }

--- a/specs/access_spec.lua
+++ b/specs/access_spec.lua
@@ -15,17 +15,18 @@ local SERVICE_TOKEN = "openwhisk_auth_token"
 
 
 describe("Plugin: openwhisk", function()
-  local proxy
-  setup(function()
+  local proxy, bp
 
-    local api1 = assert(helpers.dao.apis:insert {
+  setup(function()
+    bp = helpers.get_db_utils(nil, nil, {"openwhisk"})
+
+    local route1 = assert(bp.routes:insert {
       name         = "test-openwhisk",
       hosts        = { "test.com" },
-      upstream_url = "http://mockbin.com",
     })
 
-    assert(helpers.dao.plugins:insert {
-      api_id = api1.id,
+    assert(bp.plugins:insert {
+      route = { id = route1.id },
       name   = "openwhisk",
       config = {
         host          = HOST,


### PR DESCRIPTION
## Summary

Update for newer versions of Kong (>= 0.15).

- Update plugin schema to new DAO schema format
- Update tests - use blueprints, remove usage of APIs entity
- Bonus: add .luacheckrc

The changes were tested with a local OpenWhisk environment, following
instructions contained in `specs/access_spec.lua`.